### PR TITLE
对已经重写equal 的类，增加重写hashCode，避免相同一个对象放到hashMap 的时候判断为不相同的对象导致问题

### DIFF
--- a/femas-common/src/main/java/com/tencent/tsf/femas/common/entity/ErrorStatus.java
+++ b/femas-common/src/main/java/com/tencent/tsf/femas/common/entity/ErrorStatus.java
@@ -1,6 +1,8 @@
 package com.tencent.tsf.femas.common.entity;
 
 
+import java.util.Objects;
+
 public class ErrorStatus {
 
     public static final ErrorStatus OK = Code.OK.ToStatus();
@@ -41,6 +43,11 @@ public class ErrorStatus {
 
     public String StatusCode() {
         return Integer.toString(this.code.Value());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(code);
     }
 
     @Override

--- a/femas-common/src/main/java/com/tencent/tsf/femas/common/monitor/Endpoint.java
+++ b/femas-common/src/main/java/com/tencent/tsf/femas/common/monitor/Endpoint.java
@@ -1,5 +1,7 @@
 package com.tencent.tsf.femas.common.monitor;
 
+import java.util.Objects;
+
 public class Endpoint {
 
     private String serviceName;
@@ -56,6 +58,11 @@ public class Endpoint {
 
     public void setPort(String port) {
         this.port = port;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(serviceName, interfaceName);
     }
 
     @Override

--- a/femas-common/src/test/java/com/tencent/tsf/femas/common/entity/ErrorStatusTest.java
+++ b/femas-common/src/test/java/com/tencent/tsf/femas/common/entity/ErrorStatusTest.java
@@ -1,0 +1,30 @@
+package com.tencent.tsf.femas.common.entity;
+
+import junit.framework.TestCase;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author willJo
+ * @since 2022/3/25
+ */
+public class ErrorStatusTest extends TestCase {
+
+    @Test
+    public void test(){
+        ErrorStatus errorStatus = new ErrorStatus(ErrorStatus.Code.OK);
+        ErrorStatus errorStatus1 = new ErrorStatus(ErrorStatus.Code.OK);
+
+        Map<ErrorStatus, String> map = new HashMap<>();
+        map.put(errorStatus, "aa");
+        map.put(errorStatus1, "aa");
+
+        Assert.assertTrue(errorStatus.equals(errorStatus1));
+
+        Assert.assertEquals(map.size(), 1);
+    }
+
+}

--- a/femas-common/src/test/java/com/tencent/tsf/femas/common/monitor/EndpointTest.java
+++ b/femas-common/src/test/java/com/tencent/tsf/femas/common/monitor/EndpointTest.java
@@ -1,0 +1,42 @@
+package com.tencent.tsf.femas.common.monitor;
+
+import junit.framework.TestCase;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author willJo
+ * @since 2022/3/25
+ */
+public class EndpointTest extends TestCase {
+
+    @Test
+    public void test01() {
+        Endpoint endpoint = getEndpoint("order", "query");
+        endpoint.setIpv4("ip");
+        endpoint.setPort("8080");
+
+
+        Endpoint endpoint1 = getEndpoint("order", "query");
+
+        Map<Endpoint, String> map = new HashMap<>();
+        map.put(endpoint, "123");
+        map.put(endpoint1, "123");
+        Assert.assertTrue(endpoint.equals(endpoint1));
+        Assert.assertEquals(map.size(), 1);
+    }
+
+
+
+    private Endpoint getEndpoint(String serviceName, String interfaceName) {
+        Endpoint endpoint1 = new Endpoint();
+        endpoint1.setInterfaceName(interfaceName);
+        endpoint1.setServiceName(serviceName);
+        return endpoint1;
+    }
+
+
+}

--- a/femas-governance-impl/src/test/java/com/tencent/tsf/femas/governance/metrics/micrometer/EndPointMetricsContextTest.java
+++ b/femas-governance-impl/src/test/java/com/tencent/tsf/femas/governance/metrics/micrometer/EndPointMetricsContextTest.java
@@ -1,0 +1,94 @@
+package com.tencent.tsf.femas.governance.metrics.micrometer;
+
+import com.tencent.tsf.femas.common.monitor.Endpoint;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import junit.framework.TestCase;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author willJo
+ * @since 2022/3/25
+ */
+public class EndPointMetricsContextTest extends TestCase {
+
+    @Test
+    public void testRegister1() {
+
+        Endpoint endpoint = getEndpoint("order", "save");
+        Endpoint endpoint1 = getEndpoint("order", "save");
+
+        MeterRegistry registry = new SimpleMeterRegistry();
+        Counter counter = registry.counter("orderNum");
+        counter.increment();
+
+
+        EndPointMetricsContext.EndPointMetrics metrics = getEndPointMetrics(endpoint, counter);
+        EndPointMetricsContext.EndPointMetrics metrics1 = getEndPointMetrics(endpoint1, counter);
+
+        EndPointMetricsContext.register(metrics);
+        EndPointMetricsContext.register(metrics1);
+
+        Assert.assertEquals(1, EndPointMetricsContext.getEndPointMetricsContextCache().size());
+    }
+
+    @Test
+    public void testRegister2() {
+
+        Endpoint endpoint = getEndpoint("order", "save");
+        Endpoint endpoint1 = getEndpoint("product", "update");
+
+
+        MeterRegistry registry = new SimpleMeterRegistry();
+        Counter counter = registry.counter("orderNum");
+        counter.increment();
+
+
+        EndPointMetricsContext.EndPointMetrics metrics = getEndPointMetrics(endpoint, counter);
+        EndPointMetricsContext.EndPointMetrics metrics1 = getEndPointMetrics(endpoint1, counter);
+
+        EndPointMetricsContext.register(metrics);
+        EndPointMetricsContext.register(metrics1);
+
+        Assert.assertEquals(2, EndPointMetricsContext.getEndPointMetricsContextCache().size());
+    }
+
+    private EndPointMetricsContext.EndPointMetrics getEndPointMetrics(Endpoint endpoint, Counter counter) {
+        EndPointMetricsContext.EndPointMetrics metrics = new EndPointMetricsContext.EndPointMetrics();
+        metrics.setEndpoint(endpoint);
+        metrics.setAuthBlockedCounter(counter);
+        return metrics;
+    }
+
+    private Endpoint getEndpoint(String serviceName, String interfaceName) {
+        Endpoint endpoint1 = new Endpoint();
+        endpoint1.setInterfaceName(interfaceName);
+        endpoint1.setServiceName(serviceName);
+        return endpoint1;
+    }
+
+    @Test
+    public void testRemove() {
+        Endpoint endpoint = getEndpoint("order", "save");
+        Endpoint endpoint1 = getEndpoint("order", "save");
+
+        MeterRegistry registry = new SimpleMeterRegistry();
+        Counter counter = registry.counter("orderNum");
+        counter.increment();
+
+
+        EndPointMetricsContext.EndPointMetrics metrics = getEndPointMetrics(endpoint, counter);
+        EndPointMetricsContext.EndPointMetrics metrics1 = getEndPointMetrics(endpoint1, counter);
+
+        EndPointMetricsContext.register(metrics);
+
+
+        EndPointMetricsContext.remove(metrics1.getEndpoint());
+
+        Assert.assertEquals(0, EndPointMetricsContext.getEndPointMetricsContextCache().size());
+    }
+
+
+}


### PR DESCRIPTION
## What is the purpose of the change
重写了equal 方法的类但是没有重写hashCode 方法（具体可以查看effective java 的说明），避免相同一个对象放到hashMap 的时候判断为不相同的对象导致问题(l例如EndPointMetricsContext 中使用了Endpoint 作为hashMap 的key ，可能会导致上述所说的问题)，并且增加了相关的单元测试用例
com.tencent.tsf.femas.common.monitor.Endpoint

## Brief changelog

XX

## Verifying this change

XXXX