### PR TITLE
modify the value of spring.cloud.tencent.version is 1.3.0-greenwich SR6

### DIFF
--- a/femas-extensions/femas-extension-springcloud/femas-extension-springcloud-common/pom.xml
+++ b/femas-extensions/femas-extension-springcloud/femas-extension-springcloud-common/pom.xml
@@ -17,7 +17,7 @@
         <spring-boot-dependencies.version>2.1.13.RELEASE</spring-boot-dependencies.version>
         <spring-cloud-dependencies.version>Greenwich.SR6</spring-cloud-dependencies.version>
         <spring.cloud.alibaba.version>2.1.4.RELEASE</spring.cloud.alibaba.version>
-    	<spring.cloud.tencent.version>1.0.0.Greenwich-SNAPSHOT</spring.cloud.tencent.version>
+    	<spring.cloud.tencent.version>1.3.0-Greenwich.SR6</spring.cloud.tencent.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
modify the value of spring.cloud.tencent.version is 1.3.0-greenwich SR6.due to public maven repository hasn't exists the version of 1.0.0.Greenwich-SNAPSHOT.