### PR TITLE
fixed issue#246

### DIFF
--- a/femas-adaptor/femas-adaptor-opensource-admin/src/main/java/com/tencent/tsf/femas/adaptor/paas/config/FemasConfigGrpcClientManager.java
+++ b/femas-adaptor/femas-adaptor-opensource-admin/src/main/java/com/tencent/tsf/femas/adaptor/paas/config/FemasConfigGrpcClientManager.java
@@ -27,11 +27,15 @@ public class FemasConfigGrpcClientManager implements ServerConnectorManager {
 
     public FemasConfigGrpcClientManager() {
         String host = GrpcHepler.getPaasServerHost();
-        int port = GrpcHepler.getPaasGrpcPort();
-        channel = NettyChannelBuilder
-                .forAddress(host, port)
-                .usePlaintext()
-                .build();
+        if(StringUtils.isNotEmpty(host)){
+            int port = GrpcHepler.getPaasGrpcPort();
+            channel = NettyChannelBuilder
+                    .forAddress(host, port)
+                    .usePlaintext()
+                    .build();
+        }else {
+            log.warn("skipping initialization of grpc channel, because doesn't found the femas address configuration");
+        }
     }
 
     @Override


### PR DESCRIPTION
## What is the purpose of the change

 fix the bug, when the configure femas address is missing,start the application failed.


## Brief changelog
 modify FemasConfigGrpcClientManager.

## Verifying this change

XXXX