### PR TITLE
重写LaneInfo的hashCode和equals方法以便用于map和set中作为key

### DIFF
--- a/femas-adaptor/femas-adaptor-opensource-admin/src/main/java/com/tencent/tsf/femas/adaptor/paas/governance/lane/LaneInfo.java
+++ b/femas-adaptor/femas-adaptor-opensource-admin/src/main/java/com/tencent/tsf/femas/adaptor/paas/governance/lane/LaneInfo.java
@@ -1,6 +1,7 @@
 package com.tencent.tsf.femas.adaptor.paas.governance.lane;
 
 import java.util.List;
+import java.util.Objects;
 
 /**
  * 泳道
@@ -84,5 +85,22 @@ public class LaneInfo {
 
     public void setLaneServiceList(List<ServiceInfo> laneServiceList) {
         this.laneServiceList = laneServiceList;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        LaneInfo laneInfo = (LaneInfo) o;
+        return Objects.equals(laneId, laneInfo.laneId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(laneId);
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

<img width="879" alt="image" src="https://user-images.githubusercontent.com/22514893/193070764-d388fcf2-078c-4d32-98bb-fc7922b42af6.png">

EFFECTIVE_LANE_INFOS是个set集合，LaneInfo需用重写hashCode和equals方法以便用于作为key

## Brief changelog

XX

## Verifying this change

XXXX