### PR TITLE
fixed femas_helm service port

### DIFF
--- a/femas-helm/templates/service.yaml
+++ b/femas-helm/templates/service.yaml
@@ -8,8 +8,8 @@ spec:
   type: {{ .Values.service.type }}
   ports:
     - port: {{ .Values.service.port }}
-      targetPort: http
-      nodePort: {{ .Values.service.port }}
+      targetPort: 8080
+      nodePort: {{ .Values.service.nodePort }}
       protocol: TCP
       name: http
   selector:

--- a/femas-helm/values.yaml
+++ b/femas-helm/values.yaml
@@ -38,7 +38,8 @@ securityContext: {}
 
 service:
   type: NodePort
-  port: 32001
+  port: 8080
+  nodePort: 32001
 
 ingress:
   enabled: false


### PR DESCRIPTION
## What is the purpose of the change

1. service.port and service.nodePort are different, and can be set different value.
2. service.targetPort is the actual port on which your application is running inside the container
3. service.port user in k8s cluster, Generally do not set more than 30000