### PR TITLE
femas-admin数据中包含注册中心的用户名和密码，存在安全风险 fix_issue#289

### DIFF
--- a/femas-admin/src/main/java/com/tencent/tsf/femas/service/namespace/NamespaceMangerService.java
+++ b/femas-admin/src/main/java/com/tencent/tsf/femas/service/namespace/NamespaceMangerService.java
@@ -124,7 +124,7 @@ public class NamespaceMangerService implements ServiceExecutor {
             NamespaceVo vo = NamespaceVo.build(ns, registryConfigs);;
             if(!CollectionUtil.isEmpty(ns.getRegistryId())){
                 for(String registryId : ns.getRegistryId()){
-                    RegistryConfig config = registryManagerService.getConfigById(registryId);
+                    RegistryConfig config = registryManagerService.getSafetyConfigById(registryId);
                     if(config != null){
                         registryConfigs.add(config);
                     }

--- a/femas-admin/src/main/java/com/tencent/tsf/femas/service/registry/RegistryManagerService.java
+++ b/femas-admin/src/main/java/com/tencent/tsf/femas/service/registry/RegistryManagerService.java
@@ -162,7 +162,7 @@ public class RegistryManagerService implements ServiceExecutor {
 
     public Result<RegistryInfo> describeRegistryCluster(String registryId) {
         RegistryInfo registryInfo = new RegistryInfo();
-        RegistryConfig config = getConfigById(registryId);
+        RegistryConfig config = getSafetyConfigById(registryId);
         if (config == null) {
             return Result.success();
         }
@@ -291,7 +291,7 @@ public class RegistryManagerService implements ServiceExecutor {
         return instances;
     }
 
-
+    //查询注册中心参数
     public RegistryConfig getConfigById(String registryId) {
         RegistryConfig config = registryConfigMapCache.get(registryId);
         try {
@@ -300,6 +300,16 @@ public class RegistryManagerService implements ServiceExecutor {
             }
         } catch (Exception e) {
             log.error("registry manager get config by id failed ", e);
+        }
+        return config;
+    }
+
+    //查询去掉nacos用户名和密码的注册中心参数
+    public RegistryConfig getSafetyConfigById(String registryId) {
+        RegistryConfig config = getConfigById(registryId);
+        if (config != null) {
+            config.setUsername("");
+            config.setPassword("");
         }
         return config;
     }


### PR DESCRIPTION
## What is the purpose of the change

fix_issue#289

## Brief changelog

1. RegistryManagerService新增getSafetyConfigById方法，将nacos的用户名和密码置为空；

## Verifying this change

单元测试