### PR TITLE
修复单元测试

### DIFF
--- a/femas-governance-impl/src/main/java/com/tencent/tsf/femas/governance/ratelimit/impl/SlidingWindowRateLimiter.java
+++ b/femas-governance-impl/src/main/java/com/tencent/tsf/femas/governance/ratelimit/impl/SlidingWindowRateLimiter.java
@@ -33,7 +33,7 @@ public class SlidingWindowRateLimiter implements RateLimiter<RateLimiterRule> {
 
     @Override
     public boolean acquire(int permits) {
-        int curCount = slidingTimeWindowMetrics.getSnapshot().getTotalNumberOfCalls();
+        int curCount = slidingTimeWindowMetrics.getSnapshot().getNumberOfSuccessfulCalls();
         if (curCount + permits > limit) {
             slidingTimeWindowMetrics.record(Metrics.Outcome.BLOCK);
             return false;

--- a/femas-governance-impl/src/main/java/com/tencent/tsf/femas/governance/ratelimit/impl/SlidingWindowRateLimiter.java
+++ b/femas-governance-impl/src/main/java/com/tencent/tsf/femas/governance/ratelimit/impl/SlidingWindowRateLimiter.java
@@ -33,7 +33,7 @@ public class SlidingWindowRateLimiter implements RateLimiter<RateLimiterRule> {
 
     @Override
     public boolean acquire(int permits) {
-        int curCount = slidingTimeWindowMetrics.getSnapshot().getNumberOfSuccessfulCalls();
+        int curCount = slidingTimeWindowMetrics.getSnapshot().getTotalNumberOfCalls();
         if (curCount + permits > limit) {
             slidingTimeWindowMetrics.record(Metrics.Outcome.BLOCK);
             return false;

--- a/femas-governance-impl/src/test/java/com/tencent/tsf/femas/governance/loadbalance/TagBasedLoadbalancerTest.java
+++ b/femas-governance-impl/src/test/java/com/tencent/tsf/femas/governance/loadbalance/TagBasedLoadbalancerTest.java
@@ -38,7 +38,6 @@ public class TagBasedLoadbalancerTest {
         tags.add(tagZone1);
 
         TagBasedLoadbalancer tagBasedLoadbalancer = new TagBasedLoadbalancer(tags);
-        LoadbalancerManager.update(tagBasedLoadbalancer);
 
         // 构造Endpoint
         Set<ServiceInstance> gz = new HashSet<>();
@@ -114,19 +113,19 @@ public class TagBasedLoadbalancerTest {
         Context.getRpcInfo().setRequest(request);
 
         for (int i = 0; i < 1000; i++) {
-            ServiceInstance instance = LoadbalancerManager.select(serviceInstances);
+            ServiceInstance instance = tagBasedLoadbalancer.select(serviceInstances);
             Assert.assertTrue(gz.contains(instance));
         }
 
         serviceInstances.removeAll(gz);
         for (int i = 0; i < 1000; i++) {
-            ServiceInstance instance = LoadbalancerManager.select(serviceInstances);
+            ServiceInstance instance = tagBasedLoadbalancer.select(serviceInstances);
             Assert.assertTrue(zone1.contains(instance));
         }
 
         serviceInstances.removeAll(zone1);
         for (int i = 0; i < 1000; i++) {
-            ServiceInstance instance = LoadbalancerManager.select(serviceInstances);
+            ServiceInstance instance = tagBasedLoadbalancer.select(serviceInstances);
             Assert.assertTrue(sh.contains(instance) || zone2.contains(instance));
         }
     }


### PR DESCRIPTION
## What is the purpose of the change

修复单元测试bug. 

以下是异常信息：
java.lang.ExceptionInInitializerError
	at com.tencent.tsf.femas.plugin.impl.config.LoadBalanceConfigImpl.setDefault(LoadBalanceConfigImpl.java:56)
	at com.tencent.tsf.femas.plugin.impl.ConfigurationImpl.setDefault(ConfigurationImpl.java:133)
	at com.tencent.tsf.femas.plugin.impl.FemasPluginContext.<clinit>(FemasPluginContext.java:92)
	at com.tencent.tsf.femas.governance.loadbalance.LoadbalancerManager.<clinit>(LoadbalancerManager.java:13)
	at com.tencent.tsf.femas.governance.loadbalance.TagBasedLoadbalancerTest.testTagBasedLoadbalancer(TagBasedLoadbalancerTest.java:41)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
	at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:69)
	at com.intellij.rt.junit.IdeaTestRunner$Repeater$1.execute(IdeaTestRunner.java:38)
	at com.intellij.rt.execution.junit.TestsRepeater.repeat(TestsRepeater.java:11)
	at com.intellij.rt.junit.IdeaTestRunner$Repeater.startRunnerWithArgs(IdeaTestRunner.java:35)
	at com.intellij.rt.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:235)
	at com.intellij.rt.junit.JUnitStarter.main(JUnitStarter.java:54)
Caused by: java.lang.NullPointerException
	at com.tencent.tsf.femas.plugin.config.verify.DefaultValues.<clinit>(DefaultValues.java:43)
	... 29 more

## Brief changelog

XX

## Verifying this change

XXXX